### PR TITLE
Record what reserved bits are valid

### DIFF
--- a/Sources/WSCompression/PerMessageDeflateExtension.swift
+++ b/Sources/WSCompression/PerMessageDeflateExtension.swift
@@ -296,6 +296,9 @@ struct PerMessageDeflateExtension: WebSocketExtension {
         }
         return frame
     }
+
+    /// Reserved bits extension uses
+    var reservedBits: WebSocketFrame.ReservedBits { .rsv1 }
 }
 
 extension WebSocketExtensionFactory {

--- a/Sources/WSCore/Extensions/WebSocketExtension.swift
+++ b/Sources/WSCore/Extensions/WebSocketExtension.swift
@@ -35,6 +35,13 @@ public protocol WebSocketExtension: Sendable {
     func processReceivedFrame(_ frame: WebSocketFrame, context: WebSocketExtensionContext) async throws -> WebSocketFrame
     /// Process frame about to be sent to websocket
     func processFrameToSend(_ frame: WebSocketFrame, context: WebSocketExtensionContext) async throws -> WebSocketFrame
+    /// Reserved bits extension uses
+    var reservedBits: WebSocketFrame.ReservedBits { get }
     /// shutdown extension
     func shutdown() async
+}
+
+extension WebSocketExtension {
+    /// Reserved bits extension uses (default is none)
+    public var reservedBits: WebSocketFrame.ReservedBits { .init() }
 }

--- a/Sources/WSCore/WebSocketInboundStream.swift
+++ b/Sources/WSCore/WebSocketInboundStream.swift
@@ -67,6 +67,9 @@ public final class WebSocketInboundStream: AsyncSequence, Sendable {
                     case .pong:
                         try await self.handler.onPong(frame)
                     case .text, .binary, .continuation:
+                        guard self.handler.configuration.reservedBits.contains(frame.reservedBits) else {
+                            throw WebSocketHandler.InternalError.close(.protocolError)
+                        }
                         // apply extensions
                         var frame = frame
                         for ext in self.handler.configuration.extensions.reversed() {


### PR DESCRIPTION
Throw protocol error on receiving a frame with a reserved bit set that isnt used by a negotiated extension.

This fixes the last of the autobahn test suite tests. 