### PR TITLE
fix: Ping timeout handles send delays

### DIFF
--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -239,6 +239,7 @@ public struct WebSocketCloseFrame: Sendable {
             switch self.stateMachine.sendPing() {
             case .sendPing(let buffer):
                 try await self.write(frame: .init(fin: true, opcode: .ping, data: buffer))
+                self.stateMachine.markPingSent(bytes: buffer)
 
             case .wait(let time):
                 try await Task.sleep(for: time)

--- a/Sources/WSCore/WebSocketStateMachine.swift
+++ b/Sources/WSCore/WebSocketStateMachine.swift
@@ -101,28 +101,48 @@ struct WebSocketStateMachine {
         switch self.state {
         case .open(var state):
             if let lastPingTime = state.lastPingTime {
+                // A ping was sent. Check if we should time out
                 let timeSinceLastPing = .now - lastPingTime
-                // if time is less than timeout value, set wait time to when it would timeout
-                // and re-run loop
                 if timeSinceLastPing < self.pingTimePeriod {
+                    // Set wait time to when it would timeout and re-run loop
                     return .wait(self.pingTimePeriod - timeSinceLastPing)
                 } else {
                     return .closeConnection(.goingAway)
                 }
+            } else if let lastPingRequestedTime = state.lastPingRequestedTime {
+                // We have requested a ping, but it hasn't yet been sent. Wait until it would timeout if it was sent immediately.
+                let timeSinceLastRequestedPing = .now - lastPingRequestedTime
+                return .wait(self.pingTimePeriod - timeSinceLastRequestedPing)
+            } else {
+                // Send a new ping with a random payload
+                let random = (0..<Self.pingDataSize).map { _ in UInt8.random(in: 0...255) }
+                state.pingData.clear()
+                state.pingData.writeBytes(random)
+                state.lastPingRequestedTime = .now
+                self.state = .open(state)
+                return .sendPing(state.pingData)
             }
-            // creating random payload
-            let random = (0..<Self.pingDataSize).map { _ in UInt8.random(in: 0...255) }
-            state.pingData.clear()
-            state.pingData.writeBytes(random)
-            state.lastPingTime = .now
-            self.state = .open(state)
-            return .sendPing(state.pingData)
 
         case .closing:
             return .stop
 
         case .closed:
             return .stop
+        }
+    }
+
+    /// Mark that the ping (identified by the bytes argument) has been successfully sent
+    mutating func markPingSent(bytes: ByteBuffer) {
+        switch self.state {
+        case .open(var state):
+            guard bytes == state.pingData else {
+                // New ping has been sent.
+                return
+            }
+            state.lastPingTime = .now
+            self.state = .open(state)
+        default:
+            break
         }
     }
 
@@ -153,6 +173,7 @@ struct WebSocketStateMachine {
             // ignore pong frames with frame data not the same as the last ping
             guard frameData == state.pingData else { return }
             // clear ping data
+            state.lastPingRequestedTime = nil
             state.lastPingTime = nil
             self.state = .open(state)
 
@@ -168,10 +189,14 @@ struct WebSocketStateMachine {
 extension WebSocketStateMachine {
     struct OpenState {
         var pingData: ByteBuffer
+        // The time at which the ping was requested to be sent
+        var lastPingRequestedTime: ContinuousClock.Instant?
+        // The time at which the ping was sent. This may not match the requested time because the outbound writer may be busy.
         var lastPingTime: ContinuousClock.Instant?
 
         init() {
             self.pingData = ByteBufferAllocator().buffer(capacity: WebSocketStateMachine.pingDataSize)
+            self.lastPingRequestedTime = nil
             self.lastPingTime = nil
         }
     }

--- a/Tests/WebSocketTests/WebSocketStateMachineTests.swift
+++ b/Tests/WebSocketTests/WebSocketStateMachineTests.swift
@@ -59,10 +59,11 @@ struct WebSocketStateMachineTests {
 
     @Test func testPingLoopNoPong() {
         var stateMachine = WebSocketStateMachine(autoPingSetup: .enabled(timePeriod: .seconds(15)))
-        guard case .sendPing = stateMachine.sendPing() else {
+        guard case .sendPing(let buffer) = stateMachine.sendPing() else {
             Issue.record()
             return
         }
+        stateMachine.markPingSent(bytes: buffer)
         guard case .wait = stateMachine.sendPing() else {
             Issue.record()
             return
@@ -75,6 +76,7 @@ struct WebSocketStateMachineTests {
             Issue.record()
             return
         }
+        stateMachine.markPingSent(bytes: buffer)
         guard case .wait = stateMachine.sendPing() else {
             Issue.record()
             return
@@ -84,8 +86,49 @@ struct WebSocketStateMachineTests {
             Issue.record()
             return
         }
+        #expect(openState.lastPingRequestedTime == nil)
         #expect(openState.lastPingTime == nil)
         guard case .sendPing = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+        stateMachine.markPingSent(bytes: buffer)
+    }
+
+    @Test func testPingTimeout() async throws {
+        let timePeriod: Duration = .milliseconds(20)
+        var stateMachine = WebSocketStateMachine(autoPingSetup: .enabled(timePeriod: timePeriod))
+        guard case .sendPing(let buffer) = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+        stateMachine.markPingSent(bytes: buffer)
+        guard case .wait = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+        try await Task.sleep(for: timePeriod * 2)
+        guard case .closeConnection(_) = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+    }
+
+    @Test func testPingNotSent() async throws {
+        let timePeriod: Duration = .milliseconds(20)
+        var stateMachine = WebSocketStateMachine(autoPingSetup: .enabled(timePeriod: timePeriod))
+        guard case .sendPing(let buffer) = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+        // Don't mark as sent
+        guard case .wait = stateMachine.sendPing() else {
+            Issue.record()
+            return
+        }
+        try await Task.sleep(for: timePeriod * 2)
+        // Check that it waits indefinitely until sent
+        guard case .wait = stateMachine.sendPing() else {
             Issue.record()
             return
         }
@@ -99,6 +142,7 @@ struct WebSocketStateMachineTests {
         while true {
             switch stateMachine.sendPing() {
             case .sendPing(let buffer):
+                stateMachine.markPingSent(bytes: buffer)
                 #expect(buffer.readableBytes == 16)
                 currentBuffer = buffer
                 count += 1


### PR DESCRIPTION
This resolves an issue where if the outbound writer is blocked (for example, by a very large message), then the autoping loop may time out even if no ping has actually been sent. This occurred because the ping sent time was [recorded immediately upon calling `stateMachine.sendPing`](https://github.com/hummingbird-project/swift-websocket/blob/2c5a2171a45ed511f9381ed979c9185bb433a6cb/Sources/WSCore/WebSocketStateMachine.swift#L117), prior to [actually sending the ping through the outbound writer](https://github.com/hummingbird-project/swift-websocket/blob/2c5a2171a45ed511f9381ed979c9185bb433a6cb/Sources/WSCore/WebSocketHandler.swift#L241). The work here adjusts the connection state to differentiate between when a ping is requested, and when it has actually been sent.

Since ping/pong is intended to test the responsiveness of the other side of the socket, it seemed reasonable that blocked outbound writers shouldn't cause ping timeouts and automatic websocket closures. I'm definitely open to different opinions though.

Thanks for reviewing!