### PR TITLE
Add WebSocketOutboundWriter.writeBuffer/writeText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ xcuserdata/
 Package.resolved
 /public
 .benchmarkBaselines
+.swift-version

--- a/Sources/WSClient/WebSocketClientChannel.swift
+++ b/Sources/WSClient/WebSocketClientChannel.swift
@@ -255,7 +255,8 @@ struct WebSocketClientChannel: ClientConnectionChannel {
                     autoPing: self.configuration.autoPing,
                     closeTimeout: self.configuration.closeTimeout,
                     validateUTF8: self.configuration.validateUTF8,
-                    ignoreUncleanSSLShutdownErrors: self.configuration.ignoreUncleanSSLShutdownErrors
+                    ignoreUncleanSSLShutdownErrors: self.configuration.ignoreUncleanSSLShutdownErrors,
+                    maxFrameSize: self.configuration.maxFrameSize
                 ),
                 asyncChannel: webSocketChannel,
                 context: WebSocketClient.Context(logger: logger),

--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -69,13 +69,15 @@ public struct WebSocketCloseFrame: Sendable {
         let reservedBits: WebSocketFrame.ReservedBits
         let closeTimeout: Duration
         let ignoreUncleanSSLShutdownErrors: Bool
+        let maxFrameSize: Int
 
         @_spi(WSInternal) public init(
             extensions: [any WebSocketExtension],
             autoPing: AutoPingSetup,
             closeTimeout: Duration = .seconds(15),
             validateUTF8: Bool,
-            ignoreUncleanSSLShutdownErrors: Bool = false
+            ignoreUncleanSSLShutdownErrors: Bool = false,
+            maxFrameSize: Int = 1 << 14
         ) {
             self.extensions = extensions
             self.autoPing = autoPing
@@ -86,6 +88,7 @@ public struct WebSocketCloseFrame: Sendable {
             self.reservedBits = extensions.reduce(.init()) { partialResult, `extension` in
                 partialResult.union(`extension`.reservedBits)
             }
+            self.maxFrameSize = maxFrameSize
         }
     }
 
@@ -170,7 +173,7 @@ public struct WebSocketCloseFrame: Sendable {
                         try await self.runAutoPingLoop()
                     }
                 }
-                let webSocketOutbound = WebSocketOutboundWriter(handler: self)
+                let webSocketOutbound = WebSocketOutboundWriter(handler: self, maxFrameSize: self.configuration.maxFrameSize)
                 var inboundIterator = inbound.makeAsyncIterator()
                 let webSocketInbound = WebSocketInboundStream(
                     iterator: inboundIterator,

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -49,7 +49,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// Write buffer to websocket, breaking it up into individual frames if the buffer is too large
     ///
     /// If you are certain that the buffer will fit into your websocket frame size then use
-    /// ``WebSocketOutboundWriter.write(_:)`` instead.
+    /// ``write(_:)`` instead.
     ///
     /// - Parameter buffer: Buffer to write to websocket
     public func writeBuffer(_ buffer: ByteBuffer) async throws {
@@ -73,7 +73,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// Write string to websocket, breaking it up into individual frames if the string is too large
     ///
     /// If you are certain that the string will fit into your websocket frame size then use
-    /// ``WebSocketOutboundWriter.write(_:)`` instead.
+    /// ``write(_:)`` instead.
     ///
     /// - Parameter string: String to write to websocket
     public func writeText(_ string: String) async throws {

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -61,10 +61,10 @@ public struct WebSocketOutboundWriter: Sendable {
             // while we have bytes greater than frame size write continuation frames with fin set to false
             while buffer.readableBytes > self.maxFrameSize {
                 let slice = buffer.readSlice(length: self.maxFrameSize)!
-                try await self.handler.write(frame: .init(fin: false, opcode: .binary, data: slice))
+                try await self.handler.write(frame: .init(fin: false, opcode: .continuation, data: slice))
             }
             // write the final frame
-            try await self.handler.write(frame: .init(fin: true, opcode: .binary, data: buffer))
+            try await self.handler.write(frame: .init(fin: true, opcode: .continuation, data: buffer))
         } else {
             try await self.handler.write(frame: .init(fin: true, opcode: .binary, data: buffer))
         }

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -24,6 +24,7 @@ public struct WebSocketOutboundWriter: Sendable {
     }
 
     let handler: WebSocketHandler
+    let maxFrameSize: Int
 
     /// Write WebSocket frame
     public func write(_ frame: OutboundFrame) async throws {
@@ -42,6 +43,74 @@ public struct WebSocketOutboundWriter: Sendable {
         case .custom(let frame):
             // send custom WebSocketFrame
             try await self.handler.write(frame: frame)
+        }
+    }
+
+    /// Write buffer to websocket, breaking it up into individual frames if the buffer is too large
+    ///
+    /// If you are certain that the buffer will fit into your websocket frame size then use
+    /// ``WebSocketOutboundWriter.write(_:)`` instead.
+    ///
+    /// - Parameter buffer: Buffer to write to websocket
+    public func writeBuffer(_ buffer: ByteBuffer) async throws {
+        if buffer.readableBytes > self.maxFrameSize {
+            var buffer = buffer
+            // write first frame with opcode defining data type
+            let slice = buffer.readSlice(length: self.maxFrameSize)!
+            try await self.handler.write(frame: .init(fin: false, opcode: .binary, data: slice))
+            // while we have bytes greater than frame size write continuation frames with fin set to false
+            while buffer.readableBytes > self.maxFrameSize {
+                let slice = buffer.readSlice(length: self.maxFrameSize)!
+                try await self.handler.write(frame: .init(fin: false, opcode: .binary, data: slice))
+            }
+            // write the final frame
+            try await self.handler.write(frame: .init(fin: true, opcode: .binary, data: buffer))
+        } else {
+            try await self.handler.write(frame: .init(fin: true, opcode: .binary, data: buffer))
+        }
+    }
+
+    /// Write string to websocket, breaking it up into individual frames if the string is too large
+    ///
+    /// If you are certain that the string will fit into your websocket frame size then use
+    /// ``WebSocketOutboundWriter.write(_:)`` instead.
+    ///
+    /// - Parameter string: String to write to websocket
+    public func writeText(_ string: String) async throws {
+        if string.utf8.count > self.maxFrameSize {
+            // Use utf8span if available
+            if #available(macOS 26, iOS 26, tvOS 26, *) {
+                let span = string.utf8.span
+                var index = 0
+                // write first frame with opcode defining data type
+                let bytes = span.extracting(index..<(index + self.maxFrameSize))
+                try await self.handler.write(frame: .init(fin: false, opcode: .text, data: .init(_uint8Span: bytes)))
+                index += self.maxFrameSize
+                // while we have bytes greater than frame size write continuation frames with fin set to false
+                while span.count - index > self.maxFrameSize {
+                    let bytes = span.extracting(index..<(index + self.maxFrameSize))
+                    try await self.handler.write(frame: .init(fin: false, opcode: .continuation, data: .init(_uint8Span: bytes)))
+                    index += self.maxFrameSize
+                }
+                // write the final frame
+                let endBytes = span.extracting(index..<span.count)
+                try await self.handler.write(frame: .init(fin: true, opcode: .continuation, data: .init(_uint8Span: endBytes)))
+            } else {
+                var buffer = ByteBuffer(string: string)
+                // write first frame with opcode defining data type
+                let slice = buffer.readSlice(length: self.maxFrameSize)!
+                try await self.handler.write(frame: .init(fin: false, opcode: .text, data: slice))
+                // while we have bytes greater than frame size write continuation frames with fin set to false
+                while buffer.readableBytes > self.maxFrameSize {
+                    let slice = buffer.readSlice(length: self.maxFrameSize)!
+                    try await self.handler.write(frame: .init(fin: false, opcode: .continuation, data: slice))
+                }
+                // write the final frame
+                try await self.handler.write(frame: .init(fin: true, opcode: .continuation, data: buffer))
+            }
+        } else {
+            let buffer = ByteBuffer(string: string)
+            try await self.handler.write(frame: .init(fin: true, opcode: .text, data: buffer))
         }
     }
 
@@ -121,5 +190,13 @@ public struct WebSocketOutboundWriter: Sendable {
         }
         try await writer.finish()
         return value
+    }
+}
+
+extension ByteBuffer {
+    fileprivate init(_uint8Span bytes: Span<UInt8>) {
+        var buffer = ByteBufferAllocator().buffer(capacity: bytes.count)
+        buffer.writeBytes(bytes.bytes)
+        self = buffer
     }
 }

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -78,6 +78,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// - Parameter string: String to write to websocket
     public func writeText(_ string: String) async throws {
         if string.utf8.count > self.maxFrameSize {
+            #if compiler(>=6.2)
             // Use utf8span if available
             if #available(macOS 26, iOS 26, tvOS 26, *) {
                 let span = string.utf8.span
@@ -108,6 +109,19 @@ public struct WebSocketOutboundWriter: Sendable {
                 // write the final frame
                 try await self.handler.write(frame: .init(fin: true, opcode: .continuation, data: buffer))
             }
+            #else
+            var buffer = ByteBuffer(string: string)
+            // write first frame with opcode defining data type
+            let slice = buffer.readSlice(length: self.maxFrameSize)!
+            try await self.handler.write(frame: .init(fin: false, opcode: .text, data: slice))
+            // while we have bytes greater than frame size write continuation frames with fin set to false
+            while buffer.readableBytes > self.maxFrameSize {
+                let slice = buffer.readSlice(length: self.maxFrameSize)!
+                try await self.handler.write(frame: .init(fin: false, opcode: .continuation, data: slice))
+            }
+            // write the final frame
+            try await self.handler.write(frame: .init(fin: true, opcode: .continuation, data: buffer))
+            #endif
         } else {
             let buffer = ByteBuffer(string: string)
             try await self.handler.write(frame: .init(fin: true, opcode: .text, data: buffer))

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -207,6 +207,7 @@ public struct WebSocketOutboundWriter: Sendable {
     }
 }
 
+#if compiler(>=6.2)
 extension ByteBuffer {
     fileprivate init(_uint8Span bytes: Span<UInt8>) {
         var buffer = ByteBufferAllocator().buffer(capacity: bytes.count)
@@ -214,3 +215,4 @@ extension ByteBuffer {
         self = buffer
     }
 }
+#endif


### PR DESCRIPTION
Breaks up buffer/text into chunks if they are too big for the websocket frame size.