### PR TITLE
WebSocketClient should throw errors when server returns invalid frames

### DIFF
--- a/Sources/WSClient/WebSocketClient.swift
+++ b/Sources/WSClient/WebSocketClient.swift
@@ -13,7 +13,7 @@ public import NIOPosix
 public import NIOSSL
 public import NIOTransportServices
 import NIOWebSocket
-import WSCore
+@_spi(WSInternal) import WSCore
 
 /// WebSocket client
 ///
@@ -211,7 +211,16 @@ public struct WebSocketClient {
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
         )
-        return try await client.run()
+        do {
+            return try await client.run()
+        } catch WebSocketHandler.InternalError.close(let code) {
+            switch code {
+            case .messageTooLarge:
+                throw WebSocketClientError.serverSentMessageTooLarge
+            default:
+                throw WebSocketClientError.serverProtocolError
+            }
+        }
     }
 }
 

--- a/Sources/WSClient/WebSocketClient.swift
+++ b/Sources/WSClient/WebSocketClient.swift
@@ -217,6 +217,8 @@ public struct WebSocketClient {
             switch code {
             case .messageTooLarge:
                 throw WebSocketClientError.serverSentMessageTooLarge
+            case .dataInconsistentWithMessage:
+                throw WebSocketClientError.serverSentDataInconsistentWithMessage
             default:
                 throw WebSocketClientError.serverProtocolError
             }

--- a/Sources/WSClient/WebSocketClientError.swift
+++ b/Sources/WSClient/WebSocketClientError.swift
@@ -13,6 +13,7 @@ public struct WebSocketClientError: Swift.Error, Equatable {
         case webSocketUpgradeFailed
         case serverProtocolError
         case serverSentMessageTooLarge
+        case serverSentDataInconsistentWithMessage
         case proxyHandshakeFailed
         case proxyHandshakeInvalidResponse
         case proxyHandshakeTimeout
@@ -29,6 +30,8 @@ public struct WebSocketClientError: Swift.Error, Equatable {
     public static var webSocketUpgradeFailed: Self { .init(.webSocketUpgradeFailed) }
     /// Server protocol error.
     public static var serverProtocolError: Self { .init(.serverProtocolError) }
+    /// Server sent data inconsistent with frame type eg non-utf8 text
+    public static var serverSentDataInconsistentWithMessage: Self { .init(.serverSentDataInconsistentWithMessage) }
     /// Server sent a message that was too large
     public static var serverSentMessageTooLarge: Self { .init(.serverSentMessageTooLarge) }
     /// Proxy connection failed.
@@ -49,6 +52,7 @@ extension WebSocketClientError: CustomStringConvertible {
         case .proxyHandshakeTimeout: "Proxy handshake timed out"
         case .serverProtocolError: "Server protocol error"
         case .serverSentMessageTooLarge: "Server sent a message that was too large"
+        case .serverSentDataInconsistentWithMessage: "Server sent data inconsistent with frame type eg non-utf8 text"
         }
     }
 }

--- a/Sources/WSClient/WebSocketClientError.swift
+++ b/Sources/WSClient/WebSocketClientError.swift
@@ -11,6 +11,8 @@ public struct WebSocketClientError: Swift.Error, Equatable {
     private enum _Internal: Equatable {
         case invalidURL
         case webSocketUpgradeFailed
+        case serverProtocolError
+        case serverSentMessageTooLarge
         case proxyHandshakeFailed
         case proxyHandshakeInvalidResponse
         case proxyHandshakeTimeout
@@ -25,6 +27,10 @@ public struct WebSocketClientError: Swift.Error, Equatable {
     public static var invalidURL: Self { .init(.invalidURL) }
     /// WebSocket upgrade failed.
     public static var webSocketUpgradeFailed: Self { .init(.webSocketUpgradeFailed) }
+    /// Server protocol error.
+    public static var serverProtocolError: Self { .init(.serverProtocolError) }
+    /// Server sent a message that was too large
+    public static var serverSentMessageTooLarge: Self { .init(.serverSentMessageTooLarge) }
     /// Proxy connection failed.
     public static var proxyHandshakeFailed: Self { .init(.proxyHandshakeFailed) }
     /// Proxy connection return invalid response.
@@ -41,6 +47,8 @@ extension WebSocketClientError: CustomStringConvertible {
         case .proxyHandshakeFailed: "Proxy handshake failed"
         case .proxyHandshakeInvalidResponse: "Proxy return an invalid response during the handshake"
         case .proxyHandshakeTimeout: "Proxy handshake timed out"
+        case .serverProtocolError: "Server protocol error"
+        case .serverSentMessageTooLarge: "Server sent a message that was too large"
         }
     }
 }

--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -52,7 +52,7 @@ public struct WebSocketCloseFrame: Sendable {
 /// SPI WSInternal is used to make the WebSocket Handler available to both client and server
 /// implementations
 @_spi(WSInternal) public actor WebSocketHandler {
-    enum InternalError: Error {
+    package enum InternalError: Error {
         case close(WebSocketErrorCode)
     }
 
@@ -184,6 +184,7 @@ public struct WebSocketCloseFrame: Sendable {
                     closeCode = .normalClosure
                 } catch InternalError.close(let code) {
                     closeCode = code
+                    clientError = InternalError.close(code)
                 } catch {
                     clientError = error
                     closeCode = .unexpectedServerError

--- a/Tests/WebSocketTests/AutobahnTests.swift
+++ b/Tests/WebSocketTests/AutobahnTests.swift
@@ -73,25 +73,28 @@ struct AutobahnTests {
                 logger.info("\(info.id): \(info.description)")
 
                 // run case
-                try await WebSocketClient.connect(
-                    url: "ws://\(self.autobahnServer):9001/runCase?case=\(index)&agent=swift-websocket",
-                    configuration: .init(
-                        maxFrameSize: 16_777_216,
-                        extensions: extensions,
-                        validateUTF8: true
-                    ),
-                    logger: logger
-                ) { inbound, outbound, _ in
-                    for try await msg in inbound.messages(maxSize: .max) {
-                        switch msg {
-                        case .binary(let buffer):
-                            try await outbound.write(.binary(buffer))
-                        case .text(let string):
-                            try await outbound.write(.text(string))
+                do {
+                    try await WebSocketClient.connect(
+                        url: "ws://\(self.autobahnServer):9001/runCase?case=\(index)&agent=swift-websocket",
+                        configuration: .init(
+                            maxFrameSize: 16_777_216,
+                            extensions: extensions,
+                            validateUTF8: true
+                        ),
+                        logger: logger
+                    ) { inbound, outbound, _ in
+                        for try await msg in inbound.messages(maxSize: .max) {
+                            switch msg {
+                            case .binary(let buffer):
+                                try await outbound.write(.binary(buffer))
+                            case .text(let string):
+                                try await outbound.write(.text(string))
+                            }
                         }
                     }
+                } catch {
+                    print("\(error)")
                 }
-
                 // get case status
                 let status = try await getValue("getCaseStatus?case=\(index)&agent=swift-websocket", as: CaseStatus.self)
                 #expect(status.behavior == "OK" || status.behavior == "INFORMATIONAL" || status.behavior == "NON-STRICT")

--- a/Tests/WebSocketTests/AutobahnTests.swift
+++ b/Tests/WebSocketTests/AutobahnTests.swift
@@ -92,8 +92,8 @@ struct AutobahnTests {
                             }
                         }
                     }
-                } catch {
-                    print("\(error)")
+                } catch let error as WebSocketClientError where error == .serverProtocolError {
+                    logger.info("\(error)")
                 }
                 // get case status
                 let status = try await getValue("getCaseStatus?case=\(index)&agent=swift-websocket", as: CaseStatus.self)


### PR DESCRIPTION
Currently the client closes the connection and doesn't throw an error, so it isn't possible to work out why the connection was closed.
