### PR TITLE
Websocket client tests

### DIFF
--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -272,9 +272,8 @@ public struct WebSocketCloseFrame: Sendable {
         if self.type == .client {
             frame.maskKey = self.makeMaskKey()
         }
+        self.logger.trace("Sending \(frame.traceDescription)")
         try await self.outbound.write(frame)
-
-        self.logger.trace("Sent \(frame.traceDescription)")
     }
 
     func finish() {

--- a/Tests/WebSocketTests/ClientTests.swift
+++ b/Tests/WebSocketTests/ClientTests.swift
@@ -19,7 +19,7 @@ import Testing
 
 let magicWebSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
-struct WebSocketClientTests {
+struct WebSocketClientHTTPTests {
     /// Read HTTP headers from request. Assumes request has no body
     func readHTTPRequest(from buffer: ByteBuffer) -> (String, HTTPFields) {
         let text = String(buffer: buffer)

--- a/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
+++ b/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
@@ -1,0 +1,46 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Logging
+import NIOCore
+import NIOEmbedded
+import NIOWebSocket
+@_spi(WSInternal) import WSCore
+
+@testable import WSClient
+
+extension WebSocketClient {
+    static func test(
+        channel: NIOAsyncTestingChannel,
+        configuration: WebSocketClientConfiguration,
+        logger: Logger,
+        handler: @escaping WebSocketDataHandler<Context>
+    ) async throws -> WebSocketCloseFrame? {
+        let nioAsyncChannel = try await channel.connect(to: .init(ipAddress: "127.0.0.1", port: 8080))
+            .flatMap { _ in
+                channel.eventLoop.makeCompletedFuture {
+                    try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
+                }
+            }
+            .get()
+
+        return try await WebSocketHandler.handle(
+            type: .client,
+            configuration: .init(
+                extensions: [],
+                autoPing: configuration.autoPing,
+                closeTimeout: configuration.closeTimeout,
+                validateUTF8: configuration.validateUTF8,
+                ignoreUncleanSSLShutdownErrors: configuration.ignoreUncleanSSLShutdownErrors
+            ),
+            asyncChannel: nioAsyncChannel,
+            context: WebSocketClient.Context(logger: logger),
+            handler: handler
+        )
+    }
+}

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -12,7 +12,8 @@ import NIOEmbedded
 import NIOWebSocket
 import Testing
 import WSClient
-@_spi(WSInternal) import WSCore
+
+@testable import WSCore
 
 struct WebSocketClientTests {
     struct CloseError: Error {
@@ -61,7 +62,8 @@ struct WebSocketClientTests {
                 try await channel.writeCloseFrame(code: closeFrame.0, reason: closeFrame.1)
                 let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
                 #expect(outbound.opcode == .connectionClose)
-                try await channel.close()
+                // ignore errors from close as it appears NIOAsyncTestingChannel doesn't support half closure
+                try? await channel.close(mode: .input)
                 return .server
             }
             while let result = try await group.next() {
@@ -192,12 +194,34 @@ struct WebSocketClientTests {
     }
 
     @Test
+    func ping() async throws {
+        let logger = {
+            var logger = Logger(label: "ping")
+            logger.logLevel = .trace
+            return logger
+        }()
+
+        try await withTestWebSocketServer(logger: logger) { inbound, outbound, context in
+            context.logger.info("START CLIENT")
+            for try await _ in inbound {}
+        } server: { channel in
+            logger.info("START SERVER")
+            let pingBuffer = ByteBuffer(bytes: (0..<16).map { _ in UInt8.random(in: 0...255) })
+            try await channel.writeInbound(WebSocketFrame(fin: true, opcode: .ping, data: pingBuffer))
+            let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .pong)
+            #expect(outbound.fin == true)
+            #expect(outbound.data == pingBuffer)
+        }
+    }
+
+    @Test
     func autoPing() async throws {
         var logger = Logger(label: "autoPing")
         logger.logLevel = .trace
 
         try await withTestWebSocketServer(
-            configuration: .init(autoPing: .enabled(timePeriod: .milliseconds(100))),
+            configuration: .init(autoPing: .enabled(timePeriod: .milliseconds(200))),
             logger: logger
         ) { inbound, outbound, _ in
             for try await _ in inbound {}

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -15,17 +15,60 @@ import WSClient
 @_spi(WSInternal) import WSCore
 
 struct WebSocketClientTests {
-    func withTestWebSockerServer(
-        configuration: WebSocketClientConfiguration,
+    func createRandomBuffer(size: Int) -> ByteBuffer {
+        // create buffer
+        var data = [UInt8](repeating: 0, count: size)
+        for i in 0..<size {
+            data[i] = UInt8.random(in: 0...255)
+        }
+        return ByteBuffer(bytes: data)
+    }
+
+    @discardableResult func withTestWebSocketServer(
+        configuration: WebSocketClientConfiguration = .init(),
         logger: Logger,
         handler: @escaping WebSocketDataHandler<WebSocketClient.Context>,
         server: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws -> WebSocketCloseFrame? {
+        enum TestResult {
+            case client(Result<WebSocketCloseFrame?, any Error>)
+            case server
+        }
         let channel = NIOAsyncTestingChannel()
-        return try await withThrowingTaskGroup(of: WebSocketCloseFrame?.self) { group in
+        return try await withThrowingTaskGroup(of: TestResult.self) { group in
             group.addTask {
-
+                do {
+                    let result = try await WebSocketClient.test(channel: channel, configuration: configuration, logger: logger, handler: handler)
+                    return .client(.success(result))
+                } catch {
+                    return .client(.failure(error))
+                }
             }
+            group.addTask {
+                do {
+                    try await server(channel)
+                    try await channel.writeCloseFrame(code: .normalClosure)
+                    let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+                    #expect(outbound.opcode == .connectionClose)
+                    try await channel.close()
+                } catch {
+                    try await channel.writeCloseFrame(code: .unexpectedServerError)
+                    let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+                    #expect(outbound.opcode == .connectionClose)
+                    try await channel.close()
+                }
+                return .server
+            }
+            while let result = try await group.next() {
+                switch result {
+                case .client(let result):
+                    group.cancelAll()
+                    return try result.get()
+                case .server:
+                    break
+                }
+            }
+            fatalError("Cannot reach here")
         }
     }
 
@@ -34,5 +77,122 @@ struct WebSocketClientTests {
         var logger = Logger(label: "read")
         logger.logLevel = .trace
 
+        try await withTestWebSocketServer(logger: logger) { inbound, _, _ in
+            for try await frame in inbound {
+                #expect(frame.opcode == .text)
+                #expect(frame.data == .init(string: "Hello!"))
+            }
+        } server: { channel in
+            try await channel.writeInbound(WebSocketFrame(fin: true, opcode: .text, data: .init(string: "Hello!")))
+        }
+    }
+
+    @Test
+    func readMessage() async throws {
+        var logger = Logger(label: "readMessage")
+        logger.logLevel = .trace
+
+        try await withTestWebSocketServer(logger: logger) { inbound, _, _ in
+            for try await message in inbound.messages(maxSize: .max) {
+                #expect(message == .text("Hello, world!"))
+            }
+        } server: { channel in
+            try await channel.writeInbound(WebSocketFrame(fin: false, opcode: .text, data: .init(string: "Hello,")))
+            try await channel.writeInbound(WebSocketFrame(fin: true, opcode: .continuation, data: .init(string: " world!")))
+        }
+    }
+
+    @Test
+    func write() async throws {
+        var logger = Logger(label: "write")
+        logger.logLevel = .trace
+
+        try await withTestWebSocketServer(logger: logger) { inbound, outbound, _ in
+            try await outbound.write(.text("Hello!"))
+        } server: { channel in
+            let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .text)
+            #expect(outbound.data == .init(string: "Hello!"))
+        }
+    }
+
+    @Test
+    func textMessageWriter() async throws {
+        var logger = Logger(label: "textMessageWriter")
+        logger.logLevel = .trace
+
+        try await withTestWebSocketServer(logger: logger) { inbound, outbound, _ in
+            try await outbound.withTextMessageWriter { writer in
+                try await writer("Hello,")
+                try await writer(" world!")
+            }
+        } server: { channel in
+            var outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .text)
+            #expect(outbound.fin == false)
+            #expect(outbound.data == .init(string: "Hello,"))
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == true)
+            #expect(outbound.data == .init(string: " world!"))
+        }
+    }
+
+    @Test
+    func binaryMessageWriter() async throws {
+        var logger = Logger(label: "binaryMessageWriter")
+        logger.logLevel = .trace
+
+        let buffer = createRandomBuffer(size: 3072)
+        try await withTestWebSocketServer(logger: logger) { inbound, outbound, _ in
+            try await outbound.withBinaryMessageWriter { writer in
+                var buffer = buffer
+                try await writer(buffer.readSlice(length: 1024)!)
+                try await writer(buffer.readSlice(length: 1024)!)
+                try await writer(buffer.readSlice(length: 1024)!)
+            }
+        } server: { channel in
+            var outputBuffer = ByteBuffer()
+            var outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .binary)
+            #expect(outbound.fin == false)
+            outputBuffer.writeImmutableBuffer(outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == false)
+            outputBuffer.writeImmutableBuffer(outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == true)
+            outputBuffer.writeImmutableBuffer(outbound.data)
+            #expect(outputBuffer == buffer)
+        }
+    }
+
+    @Test
+    func serverClosedConnection() async throws {
+        var logger = Logger(label: "serverClosedConnection")
+        logger.logLevel = .trace
+
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+        let closeFrame = try await withTestWebSocketServer(configuration: .init(maxFrameSize: 1024), logger: logger) { inbound, outbound, _ in
+            cont.finish()
+            for try await _ in inbound {}
+        } server: { channel in
+            _ = await stream.first { _ in true }
+            throw CancellationError()
+        }
+        #expect(closeFrame?.closeCode == .unexpectedServerError)
+    }
+}
+
+extension NIOAsyncTestingChannel {
+    fileprivate func writeCloseFrame(code: WebSocketErrorCode = .normalClosure, reason: String? = nil) async throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 2 + (reason?.utf8.count ?? 0))
+        buffer.write(webSocketErrorCode: code)
+        if let reason {
+            buffer.writeString(reason)
+        }
+        try await self.writeInbound(WebSocketFrame(fin: true, opcode: .connectionClose, data: buffer))
     }
 }

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Logging
+import NIOCore
+import NIOEmbedded
+import NIOWebSocket
+import Testing
+import WSClient
+@_spi(WSInternal) import WSCore
+
+struct WebSocketClientTests {
+    func withTestWebSockerServer(
+        configuration: WebSocketClientConfiguration,
+        logger: Logger,
+        handler: @escaping WebSocketDataHandler<WebSocketClient.Context>,
+        server: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
+    ) async throws -> WebSocketCloseFrame? {
+        let channel = NIOAsyncTestingChannel()
+        return try await withThrowingTaskGroup(of: WebSocketCloseFrame?.self) { group in
+            group.addTask {
+
+            }
+        }
+    }
+
+    @Test
+    func read() async throws {
+        var logger = Logger(label: "read")
+        logger.logLevel = .trace
+
+    }
+}

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -15,6 +15,10 @@ import WSClient
 @_spi(WSInternal) import WSCore
 
 struct WebSocketClientTests {
+    struct CloseError: Error {
+        let errorCode: WebSocketErrorCode
+        let reason: String?
+    }
     func createRandomBuffer(size: Int) -> ByteBuffer {
         // create buffer
         var data = [UInt8](repeating: 0, count: size)
@@ -45,18 +49,19 @@ struct WebSocketClientTests {
                 }
             }
             group.addTask {
+                let closeFrame: (WebSocketErrorCode, String?)
                 do {
                     try await server(channel)
-                    try await channel.writeCloseFrame(code: .normalClosure)
-                    let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
-                    #expect(outbound.opcode == .connectionClose)
-                    try await channel.close()
+                    closeFrame = (.normalClosure, nil)
+                } catch let error as CloseError {
+                    closeFrame = (error.errorCode, error.reason)
                 } catch {
-                    try await channel.writeCloseFrame(code: .unexpectedServerError)
-                    let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
-                    #expect(outbound.opcode == .connectionClose)
-                    try await channel.close()
+                    closeFrame = (.unexpectedServerError, nil)
                 }
+                try await channel.writeCloseFrame(code: closeFrame.0, reason: closeFrame.1)
+                let outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+                #expect(outbound.opcode == .connectionClose)
+                try await channel.close()
                 return .server
             }
             while let result = try await group.next() {
@@ -175,14 +180,39 @@ struct WebSocketClientTests {
         logger.logLevel = .trace
 
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        let closeFrame = try await withTestWebSocketServer(configuration: .init(maxFrameSize: 1024), logger: logger) { inbound, outbound, _ in
+        let closeFrame = try await withTestWebSocketServer(logger: logger) { inbound, outbound, _ in
             cont.finish()
             for try await _ in inbound {}
         } server: { channel in
             _ = await stream.first { _ in true }
-            throw CancellationError()
+            throw CloseError(errorCode: .unacceptableData, reason: "Don't like it")
         }
-        #expect(closeFrame?.closeCode == .unexpectedServerError)
+        #expect(closeFrame?.closeCode == .unacceptableData)
+        #expect(closeFrame?.reason == "Don't like it")
+    }
+
+    @Test
+    func autoPing() async throws {
+        var logger = Logger(label: "autoPing")
+        logger.logLevel = .trace
+
+        try await withTestWebSocketServer(
+            configuration: .init(autoPing: .enabled(timePeriod: .milliseconds(100))),
+            logger: logger
+        ) { inbound, outbound, _ in
+            for try await _ in inbound {}
+        } server: { channel in
+            // respond to first ping to see if we receive another, don't respond to second ping
+            var outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .ping)
+            #expect(outbound.fin == true)
+            try await channel.writeInbound(WebSocketFrame(fin: true, opcode: .pong, data: outbound.data))
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .ping)
+            // If we don't cancel before 60 seconds has passed record issue
+            try await Task.sleep(for: .seconds(60))
+            Issue.record("Should have cancelled the server as the client ping timed out")
+        }
     }
 }
 


### PR DESCRIPTION
Outside of the autobahn tests swift-websocket has always relied on hummingbird-websocket to test some its more obscure edge cases. This PR adds `NIOAsyncTestingChannel` based testing to extend the testing available.