### PR TITLE
Add tests for writeBinaryMessage/writeTextMessage, WebSocketClient throwing errors

### DIFF
--- a/Sources/WSClient/WebSocketClient.swift
+++ b/Sources/WSClient/WebSocketClient.swift
@@ -11,9 +11,12 @@ public import Logging
 public import NIOCore
 public import NIOPosix
 public import NIOSSL
-public import NIOTransportServices
 import NIOWebSocket
 @_spi(WSInternal) import WSCore
+
+#if canImport(Network)
+public import NIOTransportServices
+#endif
 
 /// WebSocket client
 ///

--- a/Sources/WSCore/WebSocketFrameSequence.swift
+++ b/Sources/WSCore/WebSocketFrameSequence.swift
@@ -18,7 +18,7 @@ struct WebSocketFrameSequence {
     init(frame: WebSocketDataFrame) {
         assert(frame.opcode != .continuation, "Cannot create a WebSocketFrameSequence starting with a continuation")
         self.frames = [frame]
-        self.size = 0
+        self.size = frame.data.readableBytes
     }
 
     mutating func append(_ frame: WebSocketDataFrame) {

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -52,7 +52,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// ``write(_:)`` instead.
     ///
     /// - Parameter buffer: Buffer to write to websocket
-    public func writeBufferMessage(_ buffer: ByteBuffer) async throws {
+    public func writeBinaryMessage(_ buffer: ByteBuffer) async throws {
         if buffer.readableBytes > self.maxFrameSize {
             var buffer = buffer
             // write first frame with opcode defining data type

--- a/Sources/WSCore/WebSocketOutboundWriter.swift
+++ b/Sources/WSCore/WebSocketOutboundWriter.swift
@@ -52,7 +52,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// ``write(_:)`` instead.
     ///
     /// - Parameter buffer: Buffer to write to websocket
-    public func writeBuffer(_ buffer: ByteBuffer) async throws {
+    public func writeBufferMessage(_ buffer: ByteBuffer) async throws {
         if buffer.readableBytes > self.maxFrameSize {
             var buffer = buffer
             // write first frame with opcode defining data type
@@ -76,7 +76,7 @@ public struct WebSocketOutboundWriter: Sendable {
     /// ``write(_:)`` instead.
     ///
     /// - Parameter string: String to write to websocket
-    public func writeText(_ string: String) async throws {
+    public func writeTextMessage(_ string: String) async throws {
         if string.utf8.count > self.maxFrameSize {
             #if compiler(>=6.2)
             // Use utf8span if available

--- a/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
+++ b/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
@@ -29,19 +29,30 @@ extension WebSocketClient {
             }
             .get()
 
-        return try await WebSocketHandler.handle(
-            type: .client,
-            configuration: .init(
-                extensions: [],
-                autoPing: configuration.autoPing,
-                closeTimeout: configuration.closeTimeout,
-                validateUTF8: configuration.validateUTF8,
-                ignoreUncleanSSLShutdownErrors: configuration.ignoreUncleanSSLShutdownErrors,
-                maxFrameSize: configuration.maxFrameSize
-            ),
-            asyncChannel: nioAsyncChannel,
-            context: WebSocketClient.Context(logger: logger),
-            handler: handler
-        )
+        do {
+            return try await WebSocketHandler.handle(
+                type: .client,
+                configuration: .init(
+                    extensions: [],
+                    autoPing: configuration.autoPing,
+                    closeTimeout: configuration.closeTimeout,
+                    validateUTF8: configuration.validateUTF8,
+                    ignoreUncleanSSLShutdownErrors: configuration.ignoreUncleanSSLShutdownErrors,
+                    maxFrameSize: configuration.maxFrameSize
+                ),
+                asyncChannel: nioAsyncChannel,
+                context: WebSocketClient.Context(logger: logger),
+                handler: handler
+            )
+        } catch WebSocketHandler.InternalError.close(let code) {
+            switch code {
+            case .messageTooLarge:
+                throw WebSocketClientError.serverSentMessageTooLarge
+            case .dataInconsistentWithMessage:
+                throw WebSocketClientError.serverSentDataInconsistentWithMessage
+            default:
+                throw WebSocketClientError.serverProtocolError
+            }
+        }
     }
 }

--- a/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
+++ b/Tests/WebSocketTests/Utils/WebSocketClient+test.swift
@@ -36,7 +36,8 @@ extension WebSocketClient {
                 autoPing: configuration.autoPing,
                 closeTimeout: configuration.closeTimeout,
                 validateUTF8: configuration.validateUTF8,
-                ignoreUncleanSSLShutdownErrors: configuration.ignoreUncleanSSLShutdownErrors
+                ignoreUncleanSSLShutdownErrors: configuration.ignoreUncleanSSLShutdownErrors,
+                maxFrameSize: configuration.maxFrameSize
             ),
             asyncChannel: nioAsyncChannel,
             context: WebSocketClient.Context(logger: logger),

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -150,6 +150,31 @@ struct WebSocketClientTests {
             #expect(outbound.data == .init(string: " world!"))
         }
     }
+    @Test
+    func writeTextMessage() async throws {
+        var logger = Logger(label: "textMessageWriter")
+        logger.logLevel = .trace
+
+        let textBuffer = String((0..<3000).map { _ in "abcdefghijkl".randomElement()! })
+        try await withTestWebSocketServer(configuration: .init(maxFrameSize: 1024), logger: logger) { inbound, outbound, _ in
+            try await outbound.writeTextMessage(textBuffer)
+        } server: { channel in
+            var string = ""
+            var outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .text)
+            #expect(outbound.fin == false)
+            string += String(buffer: outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == false)
+            string += String(buffer: outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == true)
+            string += String(buffer: outbound.data)
+            #expect(string == textBuffer)
+        }
+    }
 
     @Test
     func binaryMessageWriter() async throws {

--- a/Tests/WebSocketTests/WebSocketClientTests.swift
+++ b/Tests/WebSocketTests/WebSocketClientTests.swift
@@ -20,14 +20,6 @@ struct WebSocketClientTests {
         let errorCode: WebSocketErrorCode
         let reason: String?
     }
-    func createRandomBuffer(size: Int) -> ByteBuffer {
-        // create buffer
-        var data = [UInt8](repeating: 0, count: size)
-        for i in 0..<size {
-            data[i] = UInt8.random(in: 0...255)
-        }
-        return ByteBuffer(bytes: data)
-    }
 
     @discardableResult func withTestWebSocketServer(
         configuration: WebSocketClientConfiguration = .init(),
@@ -150,6 +142,7 @@ struct WebSocketClientTests {
             #expect(outbound.data == .init(string: " world!"))
         }
     }
+
     @Test
     func writeTextMessage() async throws {
         var logger = Logger(label: "textMessageWriter")
@@ -177,11 +170,41 @@ struct WebSocketClientTests {
     }
 
     @Test
+    func writeBinaryMessage() async throws {
+        var logger = Logger(label: "writeBinaryMessage")
+        logger.logLevel = .trace
+
+        let buffer = ByteBuffer(bytes: RandomBytes(length: 3500))
+        try await withTestWebSocketServer(configuration: .init(maxFrameSize: 1024), logger: logger) { inbound, outbound, _ in
+            try await outbound.writeBinaryMessage(buffer)
+        } server: { channel in
+            var buffer2 = ByteBuffer()
+            var outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .binary)
+            #expect(outbound.fin == false)
+            buffer2.writeImmutableBuffer(outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == false)
+            buffer2.writeImmutableBuffer(outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == false)
+            buffer2.writeImmutableBuffer(outbound.data)
+            outbound = try await channel.waitForOutboundWrite(as: WebSocketFrame.self)
+            #expect(outbound.opcode == .continuation)
+            #expect(outbound.fin == true)
+            buffer2.writeImmutableBuffer(outbound.data)
+            #expect(buffer2 == buffer)
+        }
+    }
+
+    @Test
     func binaryMessageWriter() async throws {
         var logger = Logger(label: "binaryMessageWriter")
         logger.logLevel = .trace
 
-        let buffer = createRandomBuffer(size: 3072)
+        let buffer = ByteBuffer(bytes: RandomBytes(length: 3072))
         try await withTestWebSocketServer(logger: logger) { inbound, outbound, _ in
             try await outbound.withBinaryMessageWriter { writer in
                 var buffer = buffer
@@ -264,6 +287,69 @@ struct WebSocketClientTests {
             // If we don't cancel before 60 seconds has passed record issue
             try await Task.sleep(for: .seconds(60))
             Issue.record("Should have cancelled the server as the client ping timed out")
+        }
+    }
+
+    @Test
+    func serverMessageTooLargeError() async throws {
+        var logger = Logger(label: "messageTooLarge")
+        logger.logLevel = .trace
+
+        await #expect(throws: WebSocketClientError.serverSentMessageTooLarge) {
+            try await withTestWebSocketServer(
+                configuration: .init(maxFrameSize: 1024),
+                logger: logger
+            ) { inbound, outbound, _ in
+                for try await _ in inbound.messages(maxSize: 1500) {}
+            } server: { channel in
+                try await channel.writeInbound(
+                    WebSocketFrame(fin: false, opcode: .binary, data: .init(bytes: RandomBytes(length: 1024)))
+                )
+                try await channel.writeInbound(
+                    WebSocketFrame(fin: true, opcode: .continuation, data: .init(bytes: RandomBytes(length: 1024)))
+                )
+            }
+        }
+    }
+
+    @Test
+    func serverProtocolError() async throws {
+        var logger = Logger(label: "messageTooLarge")
+        logger.logLevel = .trace
+
+        await #expect(throws: WebSocketClientError.serverProtocolError) {
+            try await withTestWebSocketServer(
+                configuration: .init(maxFrameSize: 1024),
+                logger: logger
+            ) { inbound, outbound, _ in
+                for try await _ in inbound.messages(maxSize: 1500) {}
+            } server: { channel in
+                try await channel.writeInbound(
+                    WebSocketFrame(fin: false, opcode: .binary, data: .init(bytes: RandomBytes(length: 1024)))
+                )
+                try await channel.writeInbound(
+                    WebSocketFrame(fin: true, opcode: .binary, data: .init(bytes: RandomBytes(length: 1024)))
+                )
+            }
+        }
+    }
+
+    @Test
+    func serverInconsistentDataError() async throws {
+        var logger = Logger(label: "messageTooLarge")
+        logger.logLevel = .trace
+
+        await #expect(throws: WebSocketClientError.serverSentDataInconsistentWithMessage) {
+            try await withTestWebSocketServer(
+                configuration: .init(validateUTF8: true),
+                logger: logger
+            ) { inbound, outbound, _ in
+                for try await _ in inbound.messages(maxSize: 1024) {}
+            } server: { channel in
+                try await channel.writeInbound(
+                    WebSocketFrame(fin: true, opcode: .text, data: .init(repeating: 0xff, count: 16))
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Added tests writeTextMessage, writeBinaryMessage, serverMessageTooLargeError, serverProtocolError, serverInconsistentDataError
- Renamed writeText to writeTextMessage
- Renamed writeBinary to writeBinaryMessage
- Fixed issue in WebSocketFrameSequence where initial size wasn't set correctly 