### PR TITLE
Removed explicit check for `NIOSSLError.uncleanShutdown`

### DIFF
--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -212,12 +212,8 @@ public struct WebSocketCloseFrame: Sendable {
                             }
                         } catch {
                             switch self.stateMachine.state {
-                            case .closed:
-                                if self.configuration.ignoreUncleanSSLShutdownErrors == false {
-                                    throw error
-                                } else {
-                                    return
-                                }
+                            case .closed where self.configuration.ignoreUncleanSSLShutdownErrors:
+                                return
                             default:
                                 throw error
                             }

--- a/Sources/WSCore/WebSocketHandler.swift
+++ b/Sources/WSCore/WebSocketHandler.swift
@@ -8,7 +8,6 @@
 
 import Logging
 public import NIOCore
-import NIOSSL
 public import NIOWebSocket
 import ServiceLifecycle
 
@@ -211,8 +210,15 @@ public struct WebSocketCloseFrame: Sendable {
                                     }
                                 }
                             }
-                        } catch let error as NIOSSLError where error == .uncleanShutdown {
-                            if self.configuration.ignoreUncleanSSLShutdownErrors == false {
+                        } catch {
+                            switch self.stateMachine.state {
+                            case .closed:
+                                if self.configuration.ignoreUncleanSSLShutdownErrors == false {
+                                    throw error
+                                } else {
+                                    return
+                                }
+                            default:
                                 throw error
                             }
                         }


### PR DESCRIPTION
And ignore any error when in closed state.

Previously we were bringing in the whole NIOSSL module just to check if `NIOSSLError.uncleanShutdown` was being thrown. This PR changes the check to any error thrown after the state is set to closed, currently the only known errors that can be thrown are when writing the responding close frame to a received close frame (this is already ignored) and unclean shutdown errors